### PR TITLE
Minor correction, description of "port" field

### DIFF
--- a/schemas/targets/ssh.json
+++ b/schemas/targets/ssh.json
@@ -23,7 +23,7 @@
         },
         "port": {
           "type": "string",
-          "description": "The username to access this target."
+          "description": "The port of the host that should be contacted."
         },
         "username": {
           "type": "string",


### PR DESCRIPTION
Erroneous description in the description of the field "port" in "targets/ssh.json":
https://github.com/cyentific-rni/cacao-json-schemas/blob/72b550982923030343a849ba24402e16c0bc90f8/schemas/targets/ssh.json#L24-L27